### PR TITLE
Webops enhancements (UTC compatibility warning!)

### DIFF
--- a/bin/kanbanize-bugzilla-sync
+++ b/bin/kanbanize-bugzilla-sync
@@ -28,7 +28,7 @@ my $config = AppConfig->new(
     "mail-map_bugmail=%",
     
     # "bugzilla_url=s", { DEFAULT => "https://bugzilla.mozilla.org" },
-    # "kanbanize_url=s", { DEFAULT => "http://kanbanize.com" },
+    # "kanbanize_url=s", { DEFAULT => "https://kanbanize.com" },
 );
 
 $config->file("sync.cfg") if -r "sync.cfg";

--- a/bin/kanbanize-bugzilla-sync
+++ b/bin/kanbanize-bugzilla-sync
@@ -19,6 +19,7 @@ my $config = AppConfig->new(
     "kanbanize_apikey=s",
     "kanbanize_boardid=i",
     "kanbanize_incoming=s",
+    "kanbanize_priority=s",
     "bugzilla_token=s",
     "bugzilla_id=s",
     "component=s@",

--- a/lib/Net/Bugzilla/Kanbanize.pm
+++ b/lib/Net/Bugzilla/Kanbanize.pm
@@ -533,11 +533,7 @@ sub complete_card {
     if ( !$res->is_success ) {
         my $content = $res->content;
         my $status  = $res->status_line;
-        if ($content) {
-
-        } else {
-            $log->warn(Dumper($res));    #$res->status_line;
-        }
+        $log->warn("Kanban API request failed (closing $taskid): $status <<< $content >>>");
     }
 }
 

--- a/lib/Net/Bugzilla/Kanbanize.pm
+++ b/lib/Net/Bugzilla/Kanbanize.pm
@@ -556,10 +556,10 @@ sub sync_card {
             # Perhaps we need to update the card to match the bug.
             $assignee_task = 'update';
 
-              push @updated, "Update card assigned to $kanbanid";
-              #print STDERR
-              # "bug_asigned: $bug_assigned card_assigned: $card_assigned\n";
-              update_card_assigned( $card, $bug_assigned );
+            push @updated, "Update card assigned to $kanbanid";
+            #print STDERR
+            # "bug_asigned: $bug_assigned card_assigned: $card_assigned\n";
+            update_card_assigned( $card, $bug_assigned );
         }
     }
 

--- a/lib/Net/Bugzilla/Kanbanize.pm
+++ b/lib/Net/Bugzilla/Kanbanize.pm
@@ -1405,9 +1405,9 @@ sub create_card {
     }
 
     my $data = {
-        'title'   => api_encode_title("$bug->{id} - $bug->{summary}"),
-        'extlink' => "https://bugzilla.mozilla.org/show_bug.cgi?id=$bug->{id}",
-        'boardid' => $BOARD_ID,
+        'title'    => api_encode_title("$bug->{id} - $bug->{summary}"),
+        'extlink'  => "https://bugzilla.mozilla.org/show_bug.cgi?id=$bug->{id}",
+        'boardid'  => $BOARD_ID,
         'priority' => $KANBANIZE_PRIORITY,
     };
 

--- a/lib/Net/Bugzilla/Kanbanize.pm
+++ b/lib/Net/Bugzilla/Kanbanize.pm
@@ -308,16 +308,38 @@ sub get_bug_history_latest {
     return $timestamps[-1];
 }
 
+sub refresh_card {
+    my($card) = @_;
+
+    # We'll need the cardid to refresh this.
+    my($cardid) = $card->{taskid};
+
+    # Remove this card from the cache.
+    delete ${ $all_cards }{$cardid};
+
+    # Re-fetch the card.
+    return retrieve_card($cardid, 0);
+}
+
+sub get_card_history {
+    my($card) = @_;
+
+    # Ensure that we've fetched the history for this card, if it isn't already cached.
+    unless (exists $card->{'historydetails'}) {
+        # The cache is populated by get_all_tasks, which doesn't have access to history data.
+        # So we need to clear the cache and re-fetch the card, to get its history.
+        $card = refresh_card($card);
+    }
+
+    return $card;
+}
+
 sub get_card_history_latest {
     my($card, $bugid) = @_;
 
+    $card = get_card_history($card);
+
     my $cardid = $card->{'taskid'};
-
-    # The cache is populated by get_all_tasks, which doesn't have access to history data.
-    # So we need to clear the cache and re-fetch the card, to get its history.
-    delete ${ $all_cards }{$cardid};
-
-    $card = retrieve_card($cardid, $bugid);
 
     my $history = $card->{'historydetails'};
 

--- a/lib/Net/Bugzilla/Kanbanize.pm
+++ b/lib/Net/Bugzilla/Kanbanize.pm
@@ -1220,7 +1220,7 @@ sub bugmail_to_kanbanid {
   else {
     $kanbanid = 'None';
 
-    $log->warn("Unable to convert bugmail $bugmail to a valid kanbanid, resorting to 'None'.");
+    $log->debug("Unable to convert bugmail $bugmail to a valid kanbanid, resorting to 'None'.");
   }
 
   return $kanbanid;

--- a/lib/Net/Bugzilla/Kanbanize.pm
+++ b/lib/Net/Bugzilla/Kanbanize.pm
@@ -1157,8 +1157,13 @@ sub bugmail_to_kanbanid {
   if (exists $BUGMAIL_TO_KANBANID{$bugmail}) {
     $kanbanid = $BUGMAIL_TO_KANBANID{$bugmail};
   }
-  else {
+  elsif ($bugmail =~ /\@mozilla.com$/) {
     ( $kanbanid = $bugmail ) =~ s/\@.*//;
+  }
+  else {
+    $kanbanid = 'None';
+
+    $log->warn("Unable to convert bugmail $bugmail to a valid kanbanid, resorting to 'None'.");
   }
 
   return $kanbanid;

--- a/lib/Net/Bugzilla/Kanbanize.pm
+++ b/lib/Net/Bugzilla/Kanbanize.pm
@@ -656,11 +656,15 @@ sub sync_bug {
 
     $card = $new_card;
 
+    # Assuming we didn't just create a new card, we need to sync the existing card to match the bug.
+    if (@changes > 0 && $changes[-1] !~ /card created/) {
+
+        #$log->debug("Syncing card $card->{taskid} extlink << $card->{extlink} >> with bug $bug->{id} whiteboard << $bug->{whiteboard} >>") if $config->verbose;
+
+        push @changes, sync_card( $card, $bug );
+    }
+
     my $cardid = $card->{taskid};
-
-    #$log->debug("Syncing card $card->{taskid} extlink << $card->{extlink} >> with bug $bug->{id} whiteboard << $bug->{whiteboard} >>") if $config->verbose;
-
-    push @changes, sync_card( $card, $bug );
 
     if ( $config->verbose ) {
         $log->debug(sprintf "[%4d/%4d] Card %4d - Bug %8d - [%s] %s ** %s **",

--- a/lib/Net/Bugzilla/Kanbanize.pm
+++ b/lib/Net/Bugzilla/Kanbanize.pm
@@ -664,10 +664,6 @@ sub retrieve_card {
     return $all_cards->{$card_id};
 }
 
-sub sync_bugzilla {
-
-}
-
 sub sync_card {
     my ( $card, $bug ) = @_;
 

--- a/lib/Net/Bugzilla/Kanbanize.pm
+++ b/lib/Net/Bugzilla/Kanbanize.pm
@@ -533,7 +533,7 @@ sub complete_card {
     if ( !$res->is_success ) {
         my $content = $res->content;
         my $status  = $res->status_line;
-        $log->warn("Kanban API request failed (closing $taskid): $status <<< $content >>>");
+        $log->warn("Kanban API request failed while closing card #$taskid: $status <<< $content >>>");
     }
 }
 

--- a/lib/Net/Bugzilla/Kanbanize.pm
+++ b/lib/Net/Bugzilla/Kanbanize.pm
@@ -206,7 +206,7 @@ sub find_mislinked_bugs {
 }
 
 sub find_card_for_bugid {
-    my($bugid) = @_;
+    my($bugid, $skip_archived) = @_;
 
     my $bug = $bugs{$bugid};
 
@@ -218,17 +218,23 @@ sub find_card_for_bugid {
         my $extlink = $card->{extlink};
         if (defined($extlink) && $extlink =~ /show_bug.cgi.*id=$bugid$/) {
             if ($card->{columnname} eq 'Archive') {
-                # Keep the oldest archived card we find, just in case.
+                # Record the oldest archived card we find, but keep searching.
                 $found_archived ||= $card;
             } else {
+                # We found a non-archived card. Return it, since that's great.
                 return $cardid;
             }
         }
     }
 
-    # If we reached this point, either we found an archived card, or we didn't
-    # find any cards at all. Return that result, as either a card or as undef.
-    return $found_archived;
+    # If we reached this point, either we found no cards or an archived card.
+    if ($skip_archived) {
+        # We aren't supposed to return any archived cards we found, so return undef.
+        return undef;
+    } else {
+        # We return either the first archived card we found, or undef if none found.
+        return $found_archived;
+    }
 }
 
 sub find_mislinked_cards {

--- a/lib/Net/Bugzilla/Kanbanize.pm
+++ b/lib/Net/Bugzilla/Kanbanize.pm
@@ -695,8 +695,10 @@ sub unblock_card {
 sub complete_card {
     my $card = shift;
 
-    # First, unblock the card, so that we can move it.
-    unblock_card($card);
+    if ($card->{blocked} == 1) {
+        # First, unblock the card, so that we can move it.
+        unblock_card($card);
+    }
 
     my $taskid = $card->{taskid};
 

--- a/lib/Net/Bugzilla/Kanbanize.pm
+++ b/lib/Net/Bugzilla/Kanbanize.pm
@@ -1060,6 +1060,8 @@ sub update_card_extlink {
 
     $req->content( encode_json($data) );
 
+    $log->debug("Updating card $taskid extlink to << $extlink >>") if $config->verbose;
+
     my $res = $ua->request($req);
 
     if ( !$res->is_success ) {
@@ -1228,6 +1230,8 @@ sub update_card_summary {
 
     $req->content( encode_json($data) );
 
+    $log->debug("Updating card $taskid summary to << $bug_summary >>") if $config->verbose;
+
     my $res = $ua->request($req);
 
     if ( !$res->is_success ) {
@@ -1255,6 +1259,8 @@ sub update_card_assigned {
       );
 
     $req->content("[]");
+
+    $log->debug("Updating card $card->{taskid} assignee to << $assignee >>") if $config->verbose;
 
     my $res = $ua->request($req);
 
@@ -1305,6 +1311,8 @@ sub update_whiteboard {
     $whiteboard =~ s/\s+$//;
 
     $req->content("whiteboard=$whiteboard&token=$BUGZILLA_TOKEN");
+
+    $log->debug("Updating whiteboard for bug $bugid to << $whiteboard >>") if $config->verbose;
 
     my $res = $ua->request($req);
 

--- a/lib/Net/Bugzilla/Kanbanize.pm
+++ b/lib/Net/Bugzilla/Kanbanize.pm
@@ -484,19 +484,25 @@ sub sync_bug {
 
         my $found_cardid = find_card_for_bugid($bug->{id});
         if ( defined $found_cardid ) {
-            $log->warn("Bug $bug->{id} already has a card $found_cardid");
+            $card = retrieve_card($found_cardid, $bug->{id});
+
+            $log->warn("Bug $bug->{id} already has a card $found_cardid, updating whiteboard");
+
+            update_whiteboard($bug->{id}, $found_cardid, $whiteboard);
+
+            push @changes, "[bug updated]";
+        } else {
+            $card = create_card($bug);
+
+            if ( not $card ) {
+                $log->warn("Failed to create card for bug $bug->{id}");
+                return;
+            }
+
+            update_whiteboard( $bug->{id}, $card->{taskid}, $whiteboard );
+
+            push @changes, "[card created]";
         }
-
-        $card = create_card($bug);
-
-        if ( not $card ) {
-            $log->warn("Failed to create card for bug $bug->{id}");
-            return;
-        }
-
-        update_whiteboard( $bug->{id}, $card->{taskid}, $whiteboard );
-
-        push @changes, "[card created]";
     }
 
     my $new_card = retrieve_card( $card->{taskid}, $bug->{id} );

--- a/lib/Net/Bugzilla/Kanbanize.pm
+++ b/lib/Net/Bugzilla/Kanbanize.pm
@@ -223,6 +223,7 @@ sub find_mislinked_cards {
     my %extlinks = ();
 
     while ( my( $cardid, $card ) = each %{ $all_cards } ) {
+        next if $card->{columnname} eq 'Archive';
         my $extlink = $card->{extlink};
         if (defined($extlink) && $extlink =~ /show_bug.cgi.*id=(\d+)$/) {
             $extlinks{$1} ||= [];

--- a/lib/Net/Bugzilla/Kanbanize.pm
+++ b/lib/Net/Bugzilla/Kanbanize.pm
@@ -335,7 +335,7 @@ sub get_card_history {
 }
 
 sub get_card_history_latest {
-    my($card, $bugid) = @_;
+    my($card) = @_;
 
     $card = get_card_history($card);
 
@@ -737,7 +737,7 @@ sub sync_card {
     if ($assignee_task eq 'update') {
         # Find out when the card and the bug were last updated.
         my $time_bug = get_bug_history_latest($bug->{id}, 'assigned_to');
-        my $time_card = get_card_history_latest($card, $bug->{id});
+        my $time_card = get_card_history_latest($card);
 
         if ($time_bug eq $time_card) {
             # This is incredibly unlikely to occur, but if it does, we'll assume the bug is correct.

--- a/lib/Net/Bugzilla/Kanbanize.pm
+++ b/lib/Net/Bugzilla/Kanbanize.pm
@@ -796,6 +796,14 @@ sub sync_card {
         push @updated, "Updated card summary ('$bug_summary' vs '$card_summary')";
     }
 
+    # Check extlink
+    my $bug_link = "https://bugzilla.mozilla.org/show_bug.cgi?id=$bug->{id}";
+
+    if ( $card->{extlink} ne $bug_link ) {
+        update_card_extlink( $card, $bug_link );
+        push @updated, "Updated external link to bugzilla ( $card->{extlink} => $bug_link)";
+    }
+
     # Check status
     my $bug_status  = $bug->{status};
     my $card_status = $card->{columnname};
@@ -900,13 +908,7 @@ sub sync_card {
         }
     }
 
-    # Check extlink
-    my $bug_link = "https://bugzilla.mozilla.org/show_bug.cgi?id=$bug->{id}";
 
-    if ( $card->{extlink} ne $bug_link ) {
-        update_card_extlink( $card, $bug_link );
-        push @updated, "Updated external link to bugzilla ( $card->{extlink} => $bug_link)";
-    }
 
     return @updated;
 }

--- a/lib/Net/Bugzilla/Kanbanize.pm
+++ b/lib/Net/Bugzilla/Kanbanize.pm
@@ -802,7 +802,7 @@ sub sync_card {
         }
         else {
             # If it's in webops, close it, otherwise, skip it ?
-            $log->warn("Bug $bug->{id} is not RESOLVED ($bug_status) but card $card->{taskid} says $card_status");
+            $log->warn("[notimplemented] Bug $bug->{id} is not RESOLVED ($bug_status) but card $card->{taskid} says $card_status");
         }
     }
 

--- a/lib/Net/Bugzilla/Kanbanize.pm
+++ b/lib/Net/Bugzilla/Kanbanize.pm
@@ -541,7 +541,7 @@ sub get_bugs_from_all_cards {
 
     my $req =
       HTTP::Request->new( POST =>
-"http://$WHITEBOARD_TAG.kanbanize.com/index.php/api/kanbanize/get_all_tasks/boardid/$BOARD_ID/format/json"
+"https://$WHITEBOARD_TAG.kanbanize.com/index.php/api/kanbanize/get_all_tasks/boardid/$BOARD_ID/format/json"
       );
 
     $req->header( "Content-Length" => "0" );
@@ -733,7 +733,7 @@ sub retrieve_card {
 
     my $req =
       HTTP::Request->new( POST =>
-"http://$WHITEBOARD_TAG.kanbanize.com/index.php/api/kanbanize/get_task_details/boardid/$BOARD_ID/taskid/$card_id/format/json"
+"https://$WHITEBOARD_TAG.kanbanize.com/index.php/api/kanbanize/get_task_details/boardid/$BOARD_ID/taskid/$card_id/format/json"
       );
 
     $req->content( encode_json($params) );
@@ -1042,7 +1042,7 @@ sub unblock_card {
 
     my $req =
       HTTP::Request->new( POST =>
-          "http://$WHITEBOARD_TAG.kanbanize.com/index.php/api/kanbanize/block_task/format/json"
+          "https://$WHITEBOARD_TAG.kanbanize.com/index.php/api/kanbanize/block_task/format/json"
       );
 
     $req->content( encode_json($data) );
@@ -1079,7 +1079,7 @@ sub complete_card {
 
     my $req =
       HTTP::Request->new( POST =>
-          "http://$WHITEBOARD_TAG.kanbanize.com/index.php/api/kanbanize/move_task/format/json"
+          "https://$WHITEBOARD_TAG.kanbanize.com/index.php/api/kanbanize/move_task/format/json"
       );
 
     $req->content( encode_json($data) );
@@ -1111,7 +1111,7 @@ sub update_card_extlink {
 
     my $req =
       HTTP::Request->new( POST =>
-          "http://$WHITEBOARD_TAG.kanbanize.com/index.php/api/kanbanize/edit_task/format/json"
+          "https://$WHITEBOARD_TAG.kanbanize.com/index.php/api/kanbanize/edit_task/format/json"
       );
 
     $req->content( encode_json($data) );
@@ -1281,7 +1281,7 @@ sub update_card_summary {
 
     my $req =
       HTTP::Request->new( POST =>
-          "http://$WHITEBOARD_TAG.kanbanize.com/index.php/api/kanbanize/edit_task/format/json"
+          "https://$WHITEBOARD_TAG.kanbanize.com/index.php/api/kanbanize/edit_task/format/json"
       );
 
     $req->content( encode_json($data) );
@@ -1311,7 +1311,7 @@ sub update_card_assigned {
 
     my $req =
       HTTP::Request->new( POST =>
-"http://$WHITEBOARD_TAG.kanbanize.com/index.php/api/kanbanize/edit_task/format/json/boardid/$BOARD_ID/taskid/$taskid/assignee/$assignee"
+"https://$WHITEBOARD_TAG.kanbanize.com/index.php/api/kanbanize/edit_task/format/json/boardid/$BOARD_ID/taskid/$taskid/assignee/$assignee"
       );
 
     $req->content("[]");
@@ -1421,7 +1421,7 @@ sub create_card {
 
     my $req =
       HTTP::Request->new( POST =>
-"http://$WHITEBOARD_TAG.kanbanize.com/index.php/api/kanbanize/create_new_task/format/json"
+"https://$WHITEBOARD_TAG.kanbanize.com/index.php/api/kanbanize/create_new_task/format/json"
       );
 
     $req->content( encode_json($data) );
@@ -1460,7 +1460,7 @@ sub move_card {
 
     my $req =
       HTTP::Request->new( POST =>
-          "http://$WHITEBOARD_TAG.kanbanize.com/index.php/api/kanbanize/move_task/format/json"
+          "https://$WHITEBOARD_TAG.kanbanize.com/index.php/api/kanbanize/move_task/format/json"
       );
 
     $req->content( encode_json($data) );

--- a/lib/Net/Bugzilla/Kanbanize.pm
+++ b/lib/Net/Bugzilla/Kanbanize.pm
@@ -476,11 +476,24 @@ sub sync_bug {
 
     my @changes;
     if ( not defined $card ) {
+
+        # For the source to be 'card' here, the bug has to have traversed a series of logic
+        # steps to reach this point:
+        #
+        # - a card must have an extlink to the bug
+        # - the bug must not be returned by the watched components search
+        # - the bug must not have a cc: of the kanban watch user.
+        #
         if ($bug->{source} eq 'card') {
-            # This is a bug that came from a card but without a matching whiteboard...
+            # If all three of these conditions are true, then we assume the bug is not meant
+            # to be watched in Kanban, and refuse to populate the whiteboard.
+            #
+            # Improvements to this logic are pending, but not yet ready. See also:
+            # https://github.com/mozilla-it/bugzilla-kanbanize/issues/9
             $log->warn("Bug $bug->{id} came from a card, but whiteboard is empty");
             return;
         }
+        # Otherwise, the source is either 'argv' or 'cc' or 'search'. Onward to whiteboard.
 
         my $found_cardid = find_card_for_bugid($bug->{id});
         if ( defined $found_cardid ) {

--- a/lib/Net/Bugzilla/Kanbanize.pm
+++ b/lib/Net/Bugzilla/Kanbanize.pm
@@ -146,6 +146,19 @@ sub find_mislinked_bugs {
     }
 }
 
+sub find_card_for_bugid {
+    my($bugid) = @_;
+
+    for my $cardid (sort { $a <=> $b } keys %{ $all_cards }) {
+        my $extlink = $all_cards->{$cardid}->{extlink};
+        if (defined($extlink) && $extlink =~ /show_bug.cgi.*id=$bugid$/) {
+            return $cardid;
+        }
+    }
+
+    return undef;
+}
+
 sub find_mislinked_cards {
     # whiteboard link -> [ bug, bug, ... ]
     my %extlinks = ();
@@ -467,6 +480,11 @@ sub sync_bug {
             # This is a bug that came from a card but without a matching whiteboard...
             $log->warn("Bug $bug->{id} came from a card, but whiteboard is empty");
             return;
+        }
+
+        my $found_cardid = find_card_for_bugid($bug->{id});
+        if ( defined $found_cardid ) {
+            $log->warn("Bug $bug->{id} already has a card $found_cardid");
         }
 
         $card = create_card($bug);

--- a/lib/Net/Bugzilla/Kanbanize.pm
+++ b/lib/Net/Bugzilla/Kanbanize.pm
@@ -208,14 +208,27 @@ sub find_mislinked_bugs {
 sub find_card_for_bugid {
     my($bugid) = @_;
 
+    my $bug = $bugs{$bugid};
+
+    # If we find an archived card, store it in case we can't find any other card.
+    my $found_archived;
+
     for my $cardid (sort { $a <=> $b } keys %{ $all_cards }) {
-        my $extlink = $all_cards->{$cardid}->{extlink};
+        my $card = $all_cards->{$cardid};
+        my $extlink = $card->{extlink};
         if (defined($extlink) && $extlink =~ /show_bug.cgi.*id=$bugid$/) {
-            return $cardid;
+            if ($card->{columnname} eq 'Archive') {
+                # Keep the oldest archived card we find, just in case.
+                $found_archived ||= $card;
+            } else {
+                return $cardid;
+            }
         }
     }
 
-    return undef;
+    # If we reached this point, either we found an archived card, or we didn't
+    # find any cards at all. Return that result, as either a card or as undef.
+    return $found_archived;
 }
 
 sub find_mislinked_cards {

--- a/lib/Net/Bugzilla/Kanbanize.pm
+++ b/lib/Net/Bugzilla/Kanbanize.pm
@@ -47,6 +47,8 @@ sub version {
 
 #XXX: Wrong, need to be instance variables
 
+my $all_cards;
+
 my $APIKEY;
 my $BOARD_ID;
 my $BUGZILLA_TOKEN;
@@ -318,8 +320,6 @@ sub get_marked_bugs {
 
     return @bugs;
 }
-
-my $all_cards;
 
 sub get_bugs_from_all_cards {
 

--- a/lib/Net/Bugzilla/Kanbanize.pm
+++ b/lib/Net/Bugzilla/Kanbanize.pm
@@ -368,12 +368,17 @@ sub retrieve_card {
         return $all_cards->{$card_id};
     }
 
+    my $data = {
+        history => "yes",
+        event   => "update",
+    };
+
     my $req =
       HTTP::Request->new( POST =>
 "http://$WHITEBOARD_TAG.kanbanize.com/index.php/api/kanbanize/get_task_details/boardid/$BOARD_ID/taskid/$card_id/format/json"
       );
 
-    $req->header( "Content-Length" => "0" );  
+    $req->content( encode_json($data) );
 
     my $res = $ua->request($req);
 

--- a/lib/Net/Bugzilla/Kanbanize.pm
+++ b/lib/Net/Bugzilla/Kanbanize.pm
@@ -54,6 +54,7 @@ my $APIKEY;
 my $BOARD_ID;
 my $BUGZILLA_TOKEN;
 my $KANBANIZE_INCOMING;
+my $KANBANIZE_PRIORITY;
 my $WHITEBOARD_TAG;
 my @COMPONENTS;
 my @PRODUCTS;
@@ -81,6 +82,7 @@ sub run {
       or die "Please configure a bugzilla_token";
 
     $KANBANIZE_INCOMING = $config->kanbanize_incoming;
+    $KANBANIZE_PRIORITY = $config->kanbanize_priority || "Average";
 
     $WHITEBOARD_TAG = $config->tag || die "Missing whiteboard tag";
 
@@ -1406,6 +1408,7 @@ sub create_card {
         'title'   => api_encode_title("$bug->{id} - $bug->{summary}"),
         'extlink' => "https://bugzilla.mozilla.org/show_bug.cgi?id=$bug->{id}",
         'boardid' => $BOARD_ID,
+        'priority' => $KANBANIZE_PRIORITY,
     };
 
     my $req =

--- a/lib/Net/Bugzilla/Kanbanize.pm
+++ b/lib/Net/Bugzilla/Kanbanize.pm
@@ -362,7 +362,7 @@ sub fill_missing_bugs_info {
 
     foreach my $bug ( sort @found_bugs ) {
         $bugs->{ $bug->{id} } = $bug;
-        $bugs->{ $bug->{id} }{source} = $;
+        $bugs->{ $bug->{id} }{source} = $source;
     }
 
     return;

--- a/lib/Net/Bugzilla/Kanbanize.pm
+++ b/lib/Net/Bugzilla/Kanbanize.pm
@@ -48,6 +48,7 @@ sub version {
 #XXX: Wrong, need to be instance variables
 
 my $all_cards;
+my %bugs;
 
 my $APIKEY;
 my $BOARD_ID;
@@ -92,8 +93,6 @@ sub run {
     $ua->timeout(15);
     $ua->env_proxy;
     $ua->default_header( 'apikey' => $APIKEY );
-
-    my %bugs;
 
     if (@ARGV) {
         # fill_missing_bugs_info() needs to know the sourceid of each bugid.

--- a/lib/Net/Bugzilla/Kanbanize.pm
+++ b/lib/Net/Bugzilla/Kanbanize.pm
@@ -679,8 +679,10 @@ sub sync_bug {
     $card = $new_card;
 
     # Check the card extlink, if one is present, and make sure that it references the correct bug.
-    my($referenced_bug) = ($card->{extlink} =~ /show_bug.cgi.*id=(\d+)$/);
-    if (defined($referenced_bug) && $referenced_bug ne $bug->{id}) {
+    my($referenced_bug) = ($card->{extlink} =~ /show_bug.cgi.*[&?]id=(\d+)/);
+    if (!defined($referenced_bug)) {
+        $log->warn("Bug $bug->{id} references card $card->{taskid}, but the card does not point back to a properly formatted bug.");
+    } elsif ($referenced_bug ne $bug->{id}) {
         $log->warn("Bug $bug->{id} references card $card->{taskid} which references bug $referenced_bug, assigning bug $bug->{id} a new card.");
 
         my $found_cardid = find_card_for_bugid($bug->{id});

--- a/lib/Net/Bugzilla/Kanbanize.pm
+++ b/lib/Net/Bugzilla/Kanbanize.pm
@@ -707,6 +707,20 @@ sub sync_bug {
 
             push @changes, "[card created]";
         }
+    } elsif (is_archived_card($card)) {
+        # This bug references an archived card, so open a new card.
+        $log->warn("Bug $bug->{id} whiteboard << $whiteboard >> references an archived card, creating a new card");
+
+        $card = create_card($bug);
+
+        if ( not $card ) {
+            $log->warn("Failed to create card for bug $bug->{id}");
+            return;
+        }
+
+        update_whiteboard( $bug->{id}, $card->{taskid}, $whiteboard );
+
+        push @changes, "[card created]";
     }
 
     # Assuming we didn't just create a new card, we need to sync the existing card to match the bug.

--- a/lib/Net/Bugzilla/Kanbanize.pm
+++ b/lib/Net/Bugzilla/Kanbanize.pm
@@ -137,12 +137,12 @@ sub find_mislinked_bugs {
         my $card = parse_whiteboard($bug->{whiteboard});
         if (defined $card) {
             # we only need the cardid for this check.
-            my $cardid = $card->{cardid};
+            my $cardid = $card->{taskid};
             if ($cardid) {
                 # set it up to be an array, if it isn't one already.
                 $whiteboards{$cardid} ||= [];
                 # append the bug we found to the array.
-                push(@{ $whiteboards{cardid} }, $bugid);
+                push(@{ $whiteboards{$cardid} }, $bugid);
             }
         }
     }

--- a/lib/Net/Bugzilla/Kanbanize.pm
+++ b/lib/Net/Bugzilla/Kanbanize.pm
@@ -689,7 +689,7 @@ sub sync_bug {
     }
 
     # Assuming we didn't just create a new card, we need to sync the existing card to match the bug.
-    if (@changes > 0 && $changes[-1] !~ /card created/) {
+    unless (@changes > 0 && $changes[-1] =~ /card created/) {
 
         #$log->debug("Syncing card $card->{taskid} extlink << $card->{extlink} >> with bug $bug->{id} whiteboard << $bug->{whiteboard} >>") if $config->verbose;
 

--- a/lib/Net/Bugzilla/Kanbanize.pm
+++ b/lib/Net/Bugzilla/Kanbanize.pm
@@ -335,7 +335,7 @@ sub load_card_history {
 }
 
 sub get_card_history_latest {
-    my($card, $field) = @_;
+    my($card, $field, $details) = @_;
 
     $card = load_card_history($card);
 
@@ -347,6 +347,9 @@ sub get_card_history_latest {
 
     for my $change (@{ $history }) {
         next unless $change->{'historyevent'} =~ /$field/i;
+        if (defined($details)) {
+            next unless $change->{'details'} =~ /$details/;
+        }
         my $entrydate = $change->{'entrydate'};
         $entrydate =~ s/^(....-..-..) (..:..:..)$/$1T$2Z/;
         die "Unable to post-process entrydate from kanbanize" unless $entrydate =~ /^....-..-..T..:..:..Z$/;

--- a/lib/Net/Bugzilla/Kanbanize.pm
+++ b/lib/Net/Bugzilla/Kanbanize.pm
@@ -370,7 +370,7 @@ sub get_bugs {
     my $uri = URI->new("https://bugzilla.mozilla.org/rest/bug");
 
     $uri->query_param(token => $BUGZILLA_TOKEN);
-    $uri->query_param(include_fields => qw(id status whiteboard summary assigned_to));
+    $uri->query_param(include_fields => qw(id status whiteboard summary assigned_to creation_time));
     $uri->query_param(bug_status => qw(NEW UNCONFIRMED REOPENED ASSIGNED));
     $uri->query_param(product => @PRODUCTS);
     $uri->query_param(component => @COMPONENTS);

--- a/lib/Net/Bugzilla/Kanbanize.pm
+++ b/lib/Net/Bugzilla/Kanbanize.pm
@@ -216,7 +216,7 @@ sub is_archived_card {
     } elsif (defined($check_history) && $check_history) {
         # Loading the card history takes an extra API call.
         load_card_history($card);
-        if (eval { $card->{historydetails}[0]{historyevent} eq 'Task archived' }) {
+        if (eval { no warnings 'uninitialized'; $card->{historydetails}[0]{historyevent} eq 'Task archived' }) {
             # This is a permanently-archived card.
             return 1;
         }
@@ -386,6 +386,7 @@ sub get_card_history_latest {
     my @timestamps = ();
 
     for my $change (@{ $history }) {
+        next unless exists $change->{'historyevent'};
         next unless $change->{'historyevent'} =~ /$field/i;
         if (defined($details)) {
             next unless $change->{'details'} =~ /$details/;

--- a/lib/Net/Bugzilla/Kanbanize.pm
+++ b/lib/Net/Bugzilla/Kanbanize.pm
@@ -321,7 +321,7 @@ sub refresh_card {
     return retrieve_card($cardid, 0);
 }
 
-sub get_card_history {
+sub load_card_history {
     my($card) = @_;
 
     # Ensure that we've fetched the history for this card, if it isn't already cached.
@@ -337,7 +337,7 @@ sub get_card_history {
 sub get_card_history_latest {
     my($card, $field) = @_;
 
-    $card = get_card_history($card);
+    $card = load_card_history($card);
 
     my $cardid = $card->{'taskid'};
 

--- a/lib/Net/Bugzilla/Kanbanize.pm
+++ b/lib/Net/Bugzilla/Kanbanize.pm
@@ -107,6 +107,7 @@ sub run {
     $log->debug("Found a total of $count bugs");
 
     find_mislinked_bugs( \%bugs );
+    find_mislinked_cards();
 
     $total = 0;
 
@@ -141,6 +142,25 @@ sub find_mislinked_bugs {
     while ( my( $cardid, $bugids ) = each %whiteboards ) {
         if (@{ $bugids } > 1) {
             $log->warn("Card $cardid is referenced by whiteboards on multiple bugs: " . join(', ', @{ $bugids }));
+        }
+    }
+}
+
+sub find_mislinked_cards {
+    # whiteboard link -> [ bug, bug, ... ]
+    my %extlinks = ();
+
+    while ( my( $cardid, $card ) = each %{ $all_cards } ) {
+        my $extlink = $card->{extlink};
+        if (defined($extlink) && $extlink =~ /show_bug.cgi.*id=(\d+)$/) {
+            $extlinks{$1} ||= [];
+            push(@{ $extlinks{$1} }, $cardid);
+        }
+    }
+
+    while ( my( $bugid, $cardids ) = each %extlinks ) {
+        if (@{ $cardids } > 1) {
+            $log->warn("Bug $bugid is referenced by extlinks on multiple cards: " . join(', ', @{ $cardids }));
         }
     }
 }

--- a/lib/Net/Bugzilla/Kanbanize.pm
+++ b/lib/Net/Bugzilla/Kanbanize.pm
@@ -335,7 +335,7 @@ sub get_card_history {
 }
 
 sub get_card_history_latest {
-    my($card) = @_;
+    my($card, $field) = @_;
 
     $card = get_card_history($card);
 
@@ -346,7 +346,7 @@ sub get_card_history_latest {
     my @timestamps = ();
 
     for my $change (@{ $history }) {
-        next unless $change->{'historyevent'} =~ /assignee/i;
+        next unless $change->{'historyevent'} =~ /$field/i;
         my $entrydate = $change->{'entrydate'};
         $entrydate =~ s/^(....-..-..) (..:..:..)$/$1T$2Z/;
         die "Unable to post-process entrydate from kanbanize" unless $entrydate =~ /^....-..-..T..:..:..Z$/;
@@ -657,7 +657,6 @@ sub retrieve_card {
 
     my $params = {
         history => "yes",
-        event   => "update",
     };
 
     my $req =
@@ -737,7 +736,7 @@ sub sync_card {
     if ($assignee_task eq 'update') {
         # Find out when the card and the bug were last updated.
         my $time_bug = get_bug_history_latest($bug->{id}, 'assigned_to');
-        my $time_card = get_card_history_latest($card);
+        my $time_card = get_card_history_latest($card, 'assignee');
 
         if ($time_bug eq $time_card) {
             # This is incredibly unlikely to occur, but if it does, we'll assume the bug is correct.

--- a/lib/Net/Bugzilla/Kanbanize.pm
+++ b/lib/Net/Bugzilla/Kanbanize.pm
@@ -708,8 +708,8 @@ sub sync_bug {
 
             push @changes, "[card created]";
         }
-    } elsif (is_archived_card($card)) {
-        # This bug references an archived card, so open a new card.
+    } elsif (is_archived_card($card) && ($bug->{status} !~ /^(RESOLVED|VERIFIED)$/)) {
+        # If the bug is open, and references an archived card, open a new card.
         $log->warn("Bug $bug->{id} whiteboard << $whiteboard >> references an archived card, creating a new card");
 
         $card = create_card($bug);

--- a/lib/Net/Bugzilla/Kanbanize.pm
+++ b/lib/Net/Bugzilla/Kanbanize.pm
@@ -1049,10 +1049,17 @@ sub update_whiteboard {
         $whiteboard =~ s{kanban:$WHITEBOARD_TAG:https://kanbanize.com/ctrl_board/\d+/\d+}{};
     }
 
+    # Clear new qualified whiteboards
 
+    if ($whiteboard =~ m{\[kanban:https://$WHITEBOARD_TAG.kanbanize.com/ctrl_board/\d+/\d+\]\s*} ) {
+        $whiteboard =~ s{\[kanban:https://$WHITEBOARD_TAG.kanbanize.com/ctrl_board/\d+/\d+\]\s*}{};
+    }
 
     $whiteboard =
       "[kanban:https://$WHITEBOARD_TAG.kanbanize.com/ctrl_board/$BOARD_ID/$cardid] $whiteboard";
+
+    # General whitespace cleanup, so that we don't pollute the whiteboard too much.
+    $whiteboard =~ s/\s+$//;
 
     $req->content("whiteboard=$whiteboard&token=$BUGZILLA_TOKEN");
 

--- a/sync-dist.cfg
+++ b/sync-dist.cfg
@@ -2,6 +2,7 @@
 kanbanize_apikey=
 kanbanize_boardid=
 kanbanize_incoming="Pending Triage"
+kanbanize_priority="Average"
 
 # The API key must be associated with a user whose timezone is UTC.
 # Otherwise, syncing-related time comparisons with Bugzilla will fail.

--- a/sync-dist.cfg
+++ b/sync-dist.cfg
@@ -3,6 +3,9 @@ kanbanize_apikey=
 kanbanize_boardid=
 kanbanize_incoming="Pending Triage"
 
+# The API key must be associated with a user whose timezone is UTC.
+# Otherwise, syncing-related time comparisons with Bugzilla will fail.
+
 bugzilla_token=
 bugzilla_id=
 


### PR DESCRIPTION
Hi, various fixes from Webops here for you. With the exception of today's commits for mozilla-it/bugzilla-kanbanize#27, the rest of these changes have been running successfully with no detected issues for a month or two.

THIS CONTAINS A BREAKING CHANGE. Two-way syncing of bug and card changes uses the last-modified timestamp of the relevant field to resolve conflicts. The Kanbanize API user _must_ be set to UTC prior to deploying these changes. Any other timezone will result in conflicts being resolved incorrectly.

Fixed issues and features implemented:
- mozilla-it/bugzilla-kanbanize#27
- mozilla-it/bugzilla-kanbanize#17
- mozilla-it/bugzilla-kanbanize#13
- mozilla-it/bugzilla-kanbanize#10
- mozilla-it/bugzilla-kanbanize#9
- mozilla-it/bugzilla-kanbanize#7
- mozilla-it/bugzilla-kanbanize#6
- mozilla-it/bugzilla-kanbanize#4
- mozilla-it/bugzilla-kanbanize#3
- mozilla-it/bugzilla-kanbanize#2
